### PR TITLE
isValidators: no-evaluators attribute

### DIFF
--- a/dynamic/dynamic-abstract-beacon-chain.md
+++ b/dynamic/dynamic-abstract-beacon-chain.md
@@ -267,7 +267,7 @@ rule #Ceil(values(_:Map)) => #True [anywhere]
 
 ```k
 // abstract predicate
-syntax Bool ::= isValidators(Map) [function, functional]
+syntax Bool ::= isValidators(Map) [function, functional, no-evaluators]
 
 syntax Bool ::= isValidatorsList(List) [function, functional]
 rule isValidatorsList(values(M:Map)) => isValidators(M)


### PR DESCRIPTION
The `no-evaluators` attribute signals to the backend that we did not define any
evaluation rules for the `isValidators` function, to suppress the backend's
warning about the absence of such rules.